### PR TITLE
Force team logos to be 30px

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -124,11 +124,16 @@ function createMarker(pos, t) {
 			lat: pos.lat + ((Math.random() / 100) * ((Math.random() >= 0.5) ? -1 : 1)),
 			lng: pos.lng + ((Math.random() / 100) * ((Math.random() >= 0.5) ? -1 : 1))
 		};
+		var custom = icons.indexOf(t) !== -1;
+		var image = {
+			url: custom ? 'logos/' + t + '.png' : 'marker.png',
+			scaledSize: custom ? new google.maps.Size(30, 30) : undefined
+		};
 		var marker = new google.maps.Marker({
 			position: pos,
 			map: map,
 			title: t + '',
-			icon: (icons.indexOf(t) != -1) ? 'logos/' + t + '.png' : 'marker.png'
+			icon: image
 		});
 		google.maps.event.addListener(marker, 'click', function() {
 			openInfo(t, marker);


### PR DESCRIPTION
This will prevent the need to check if each individual image is of appropriate dimensions. In my opinion, 40px was way too large, so I set it to 30px. This will not affect existing images as they will be scaled down to 30px.

-----

With 30px custom icons:
![screen shot 2016-10-06 at 9 54 06 pm](https://cloud.githubusercontent.com/assets/10191084/19179182/af3c0978-8c0f-11e6-8416-b27859c1d157.png)

-----

With 40px custom icons:
![screen shot 2016-10-06 at 9 55 02 pm](https://cloud.githubusercontent.com/assets/10191084/19179190/b85c7f24-8c0f-11e6-8b0a-87299c08e908.png)
![screen shot 2016-10-06 at 9 55 16 pm](https://cloud.githubusercontent.com/assets/10191084/19179191/bcb6f4e6-8c0f-11e6-9917-fded0a2105fa.png)

