### PR TITLE
Change loading background color

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,9 +17,13 @@ body {
 body {
     font-family: 'Roboto', sans-serif;
     font-weight: 100;
+    background-color: #173340;
 }
 #map {
     height: 100%;
+}
+.gm-style {
+    background-color: #173340 !important;
 }
 .gm-style-iw {
     border-radius: 2px 2px 0 0;


### PR DESCRIPTION
This changes the background color when the page initially loads and the background of the Google Maps loading page. This makes the overall loading experience much more clean and less harsh.

-----

Without loading background color:
![w/o](https://i.gyazo.com/fb7800d2509c12b637e9eca068196b36.gif)

-----

With loading background color:
![with](https://i.gyazo.com/982cff5dc76c50a488925aacfdfca3bf.gif)