### PR TITLE
Get avatars from frccards.com instead of loading base64 images

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,6 @@
 
     <!-- Javascript Scripts -->
     <script src="data/teamInfo.js"></script>
-    <script src="data/teamAvatars.js"></script>
     <script src="data/events.js"></script>
     <script src="overrides.js"></script>
     <script src="resources/scripts.js"></script>

--- a/resources/scripts.js
+++ b/resources/scripts.js
@@ -7,6 +7,9 @@
 var map
 var markers = []
 
+// Teams who have an avatar
+var teamAvatars = []
+
 // Start all markers in displayable state (not hidden)
 var state = {T: true, R: true, D: true, C:true}
 
@@ -134,8 +137,18 @@ function initMap() {
 
 // Create team and event markers
 
-    for (i = 0; i < teamInfo.length; i++) {
-        createTeamMarker(teamInfo[i])
+    var req = new XMLHttpRequest()
+
+    req.open('GET', 'https://frccards.com/avatars/teams.json')
+    req.send()
+    req.onreadystatechange = function() {
+      if (req.readyState === 4 && req.status === 200) {
+        teamAvatars = JSON.parse(req.responseText)
+
+        for (i = 0; i < teamInfo.length; i++) {
+            createTeamMarker(teamInfo[i])
+        }
+      }
     }
 
     for (i = 0; i < events.length; i++) {
@@ -201,9 +214,9 @@ function createTeamMarker(teamInfo) {
         if (custom){
           imageUrl = 'logos/' + title + '.png'
         } else {
-          if (teamAvatars[title]) {
-            custom=true;
-            imageUrl = 'data:image/png;base64,' + teamAvatars[title]["img"]
+          if (teamAvatars.indexOf(title) >= 0) {
+            custom = true;
+            imageUrl = 'https://frccards.com/avatars/' + title + '.png'
           }
         }
 

--- a/resources/scripts.js
+++ b/resources/scripts.js
@@ -216,7 +216,6 @@ function createTeamMarker(teamInfo) {
         } else if (teamAvatars.indexOf(title) >= 0) {
             custom = true;
             imageUrl = 'https://frccards.com/avatars/' + title + '.png'
-          }
         }
 
         var image = {

--- a/resources/scripts.js
+++ b/resources/scripts.js
@@ -213,8 +213,7 @@ function createTeamMarker(teamInfo) {
         var imageUrl = 'resources/marker.png'
         if (custom){
           imageUrl = 'logos/' + title + '.png'
-        } else {
-          if (teamAvatars.indexOf(title) >= 0) {
+        } else if (teamAvatars.indexOf(title) >= 0) {
             custom = true;
             imageUrl = 'https://frccards.com/avatars/' + title + '.png'
           }


### PR DESCRIPTION
frccards.com is a new service that I host that will offer cool things like embeddable team widgets, match results and stuff. I have also uploaded every team avatars and will periodically update it to make sure it is always up-to-date.

I've done some testing and getting avatars from frccards takes less time to load and actually takes less bandwith overall. It's also easier to update.