### PR TITLE
Updated KeyCode to toggle Offseason Events.  (76 ->> 79)

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -265,7 +265,7 @@ function addKeyboardListener() {
                 toggleMarkers('district');
                 break;
             // O
-            case 76:
+            case 79:
                 toggleMarkers('offseason');
                 break;
             // R


### PR DESCRIPTION
KeyCode was previously 76 to toggle Off-season events, but still marked as O.  However, KeyCode 76 actually points to the letter "L".  Thus, the case statement has been updated to use 79 instead - the proper KeyCode.