### PR TITLE
Use date string from TBA for events rather than parsing and reformatt…

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -222,8 +222,8 @@ function openInfo(marker) {
                 if (parsed.week) {
                     content += '<li><strong>Week:</strong> ' + parsed.week + '</li>';
                 }
-                var start = new Date(parsed.start_date).toLocaleDateString();
-                var end = new Date(parsed.end_date).toLocaleDateString();
+                var start = /*new Date(*/parsed.start_date/*).toLocaleDateString()*/;
+                var end = /*new Date(*/parsed.end_date/*).toLocaleDateString()*/;
                 content += '<li><strong>Date:</strong> ' + start + ' - ' + end + '</li>';
                 content += '<li><a href="http://www.thebluealliance.com/event/' + marker.key + '">View on The Blue Alliance</a></li>';
                 content += '</ul>';


### PR DESCRIPTION
Quick and Dirty correction to date advancement seen (at least) on firefox and MS Edge in the western hemisphere.  Skips the known problematic date parser and just uses the YYYY-MM-DD format generated by TBA.

 Use date string from TBA for events rather than parsing and reformatting.

The Javascript parser does not work consistently across platforms.
On Firefox in the western hemisphere, all dates are advanced one day.