### PR TITLE
Try 2:  Added POST Argument Scanner

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1,18 +1,26 @@
 // Google Map
 var map;
-var markers = [];
+var markers = {
+    all: [],
+    keys: {},
+}
 
-// Show all markers
-var state = {team: true, regional: true, district: true, championship: true, offseason: true};
+// URL Parsing / POST Argument Tools
+var url = new URL(window.location.href);
+var params = url.searchParams;
+
 
 function initMap() {
+    state = parseVisibility(); // Update State before Map Generation
+
+    
     // Initialize Google Map
     map = new google.maps.Map(document.getElementById('map'), {
         center: {
-            lat: 30,
-            lng: 0
+            lat: parseFloat(params.get('lat')) || 30,
+            lng: parseFloat(params.get('lng')) || 0
         },
-        zoom: 2,
+        zoom: parseInt(params.get('zoom')) || 2,
         disableDefaultUI: true,
         zoomControl: true,
         mapTypeControl: false,
@@ -113,10 +121,44 @@ function initMap() {
     });
 
     // Create team and event markers
-    for (team  of  teams)   createTeamMarker(team);
     for (event of events) createEventMarker(event);
+    for (team  of  teams)   createTeamMarker(team);
+    
+    openURLKey(); // Open / Zoom to Marker Specified in URL
 
-    addKeyboardListener();
+    // Add Map State Listeners (Center & Zoom)
+    map.addListener('center_changed', function() {
+        lat = map.center.lat();
+        lng = map.center.lng();
+
+        if (lat == 30) {
+            params.delete('lat');
+        } else {
+            params.set('lat', lat);
+        }
+
+        if (lng == 0) {
+            params.delete('lng');
+        } else {
+            params.set('lng', lng);
+        }
+        
+        window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+    });
+
+    map.addListener('zoom_changed', function() {
+        zoom = map.zoom;
+
+        if (zoom == 2) {
+            params.delete('zoom');
+        } else {
+            params.set('zoom', zoom);
+        }
+
+        window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+    });
+
+    addKeyboardListener(); // Marker Toggling via Keyboard
 }
 
 function createEventMarker(event) {
@@ -137,9 +179,12 @@ function createEventMarker(event) {
 
     google.maps.event.addListener(marker, 'click', function() {
         openInfo(marker);
+        params.set('key', event.key);
+        window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
     });
 
-    markers.push(marker);
+    markers.all.push(marker);
+    markers.keys[event.key] = marker;
 }
 
 function createTeamMarker(team) {
@@ -156,13 +201,18 @@ function createTeamMarker(team) {
             lng: team.lng + (Math.random() - .5) / 50
         };
     }
-    var custom = icons.indexOf(team.team_number) !== -1;
+    
     var image = 'img/team.png';
-    if (custom) {
-        image = 'logos/' + team.team_number + '.png';
-    } else if (avatars[team.team_number]) {
-        custom = true;
-        image = 'data:image/png;base64,' + avatars[team.team_number]['img'];
+
+    allow_logos = !(params.get('logos') == 'false');
+    if (allow_logos) {
+        var custom = icons.indexOf(team.team_number) !== -1;
+        if (custom) {
+            image = 'logos/' + team.team_number + '.png';
+        } else if (avatars[team.team_number]) {
+            custom = true;
+            image = 'data:image/png;base64,' + avatars[team.team_number]['img'];
+        }
     }
 
     var marker = new google.maps.Marker({
@@ -179,9 +229,12 @@ function createTeamMarker(team) {
 
     google.maps.event.addListener(marker, 'click', function() {
         openInfo(marker);
+        params.set('key', 'frc' + team.team_number);
+        window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
     });
 
-    markers.push(marker);
+    markers.all.push(marker);
+    markers.keys['frc' + team.team_number] = marker;
 }
 
 function openInfo(marker) {
@@ -239,14 +292,22 @@ function openInfo(marker) {
             });
 
             infoWindow.open(map, marker);
+
+            infoWindow.addListener('closeclick', function() {
+                if (params.get('key')) {
+                    params.delete('key');
+                    window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+                }
+            });
         }
     }
 }
 
 function toggleMarkers(type) {
     state[type] = !state[type];
-    for (marker of markers)
-        if (marker.type === type) marker.setMap(state[type] ? map : null);
+    updateVisibility();
+    for (marker of markers.all)
+        if (marker.type === type) marker.setVisible(state[type]);
 }
 
 function addKeyboardListener() {
@@ -282,6 +343,95 @@ function addKeyboardListener() {
                 break;
         }
     })
+}
+
+// Parse Marker Visibility from URL POST Arguments
+function parseVisibility() {
+    visibility = params.get('visibility');
+
+    if (visibility == null || visibility == 'all') {
+        return {team: true, regional: true, district: true, championship: true, offseason: true};
+    } else {
+        return {
+            team: visibility.includes('t'),
+            regional: visibility.includes('e') || visibility.includes('r'),
+            district: visibility.includes('e') || visibility.includes('d'),
+            championship: visibility.includes('e') || visibility.includes('c'),
+            offseason: visibility.includes('e') || visibility.includes('o'),
+        }
+    }
+}
+
+// Update URL with current Marker Visibility State
+function updateVisibility() {
+    all_visible = true ? state.team && state.regional && state.district && state.championship && state.offseason : false;
+
+    if (all_visible) {
+        params.delete('visibility');
+        window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+        return
+    }
+
+    now_visible = [];
+
+    if (state.regional && state.district && state.championship && state.offseason)
+        now_visible.push('e');
+
+    if (state.team)
+        now_visible.push('t');
+
+    if (!now_visible.includes('e')) {
+        if (state.regional)
+            now_visible.push('r');
+
+        if (state.district)
+            now_visible.push('d');
+
+        if (state.championship)
+            now_visible.push('c');
+        
+        if (state.offseason)
+            now_visible.push('o');
+    }
+
+    if (now_visible.length == 0){
+        params.set('visibility', 'none');
+    } else {
+        params.set('visibility', now_visible.join("-"));
+    }
+    
+    window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+}
+
+// Handle Zoom / Reposition / Info Panel of URL specified marker key
+function openURLKey() {
+    keyToOpen = params.get('key');
+    if (!keyToOpen) return;
+    markerToOpen = markers.keys[keyToOpen];
+    if (!markerToOpen) return;
+
+    if (!params.get('lat') && !params.get('lng')) {
+        map.panTo(markerToOpen.getPosition());
+        setTimeout(deleteLatLng, 1500);
+    }
+
+    if (!params.get('zoom')) {
+        map.setZoom(12);
+        setTimeout(deleteZoom, 1500);
+    }
+
+    openInfo(markerToOpen);
+}
+
+function deleteLatLng() {  // Remove Lat/Lng POST arguments from URL
+    params.delete('lat');
+    params.delete('lng');
+    window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+}
+
+function deleteZoom() { // Remove Zoom POST arguments from URL
+    params.delete('zoom');
+    window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
 }
 
 var about = document.getElementById('about');

--- a/scripts.js
+++ b/scripts.js
@@ -143,7 +143,7 @@ function initMap() {
             params.set('lng', lng);
         }
         
-        window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+        pushHistory();
     });
 
     map.addListener('zoom_changed', function() {
@@ -155,7 +155,7 @@ function initMap() {
             params.set('zoom', zoom);
         }
 
-        window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+        pushHistory();
     });
 
     addKeyboardListener(); // Marker Toggling via Keyboard
@@ -180,7 +180,7 @@ function createEventMarker(event) {
     google.maps.event.addListener(marker, 'click', function() {
         openInfo(marker);
         params.set('key', event.key);
-        window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+        pushHistory();
     });
 
     markers.all.push(marker);
@@ -230,7 +230,7 @@ function createTeamMarker(team) {
     google.maps.event.addListener(marker, 'click', function() {
         openInfo(marker);
         params.set('key', 'frc' + team.team_number);
-        window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+        pushHistory();
     });
 
     markers.all.push(marker);
@@ -296,7 +296,7 @@ function openInfo(marker) {
             infoWindow.addListener('closeclick', function() {
                 if (params.get('key')) {
                     params.delete('key');
-                    window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+                    pushHistory();
                 }
             });
         }
@@ -368,7 +368,7 @@ function updateVisibility() {
 
     if (all_visible) {
         params.delete('visibility');
-        window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+        pushHistory();
         return
     }
 
@@ -400,7 +400,7 @@ function updateVisibility() {
         params.set('visibility', now_visible.join("-"));
     }
     
-    window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+    pushHistory();
 }
 
 // Handle Zoom / Reposition / Info Panel of URL specified marker key
@@ -426,11 +426,21 @@ function openURLKey() {
 function deleteLatLng() {  // Remove Lat/Lng POST arguments from URL
     params.delete('lat');
     params.delete('lng');
-    window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+    pushHistory();
 }
 
 function deleteZoom() { // Remove Zoom POST arguments from URL
     params.delete('zoom');
+    pushHistory();
+}
+
+lastUpdate = 0; // Last time map was updated
+updateDelay = 1000; // 1 Second Update Delay
+
+function pushHistory() { // Push History State to URL
+    if (lastUpdate >= (Date.now() - updateDelay)) return;
+    lastUpdate = Date.now();
+
     window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
 }
 


### PR DESCRIPTION
Hey Guys!  Once again, I'm sorry about my last try at this Pull Request.  Due to my current technological situation, I had to jump around between computers while working on this in my free time, and it looks like incompatible git versions and differing operating systems lead to the line ending commit glitch that was causing issues.  I hoped I could have fixed it within the same Pull Request, but nothing I was trying was working properly and the only suggestion I could get out of Stack Overflow was basically to reset to origin and reintegrate the changes (especially due to the other pull request that was recently merged).  Hopefully this PR turns out a little better :)

Now on to the actual PR, which I'll review here for the sake of clarity.

This Pull Request implements a POST Argument scanner that allows various map states to be saved and transferred between users, computers, and browsers via the sharing of state-unique URLs.  Upon page-load, the map will load into the desired state as set in the URL.  This system should hopefully allow users to share desired map sections or highlighted teams between each other much more easily.

The POST Arguments supported by this PR are as follows:

`?visibility={}` - This argument loads the map into a given marker visibility state.  This state is stored as a combination of various letters representing which categories of markers will be shown.  (ex: `?visibility=tdc`)  This string will be automatically updated via the History Management API as marker categories are shown / hidden via the GUI.  These indicator letters are as follows:
- `t` = teams
- `e` = all events
- `r` = regional events
- `d` = district events
- `c` = championship events
- `o` = off-season events
- `all` = all markers (equivalent to no parameter)

`?lat={}`. `?lng={}`, `?zoom={}` - This argument loads the map positioned on a given set of coordinates at a given zoom level instead of the default position and zoom.  All three of these arguments are optional, and any value will return to default if not included.  All three arguments will also be automatically updated via the History Management API as long as they are not at their default positions.

`?logos=false` - This arguement disables custom team logos.  The only supported value at this time is `false`, and any other value will be ignored.  This argument should cut down on load time and intensity, especially on older machines or those with slower internet connections.

`?key={}` - This argument will cause the map to load with a given marker already open.  If no `lat`/`lng` or `zoom` are provided, the map will also pan to this marker and zoom in to a generally appropriate level.  However, if coordinates and zoom levels are provided, the map will honor those and simply open the marker information panel. This key will be automatically added / updated / removed via the History Management API as markers are opened and closed.


Again, sorry about the last PR and the issues it contained.  I have double and triple checked this one, and everything seems to be fine this time.  However, if anything needs to be modified or fixed, let me know.  I picked up this addition simply as something to do here and there because things are a little slow during the summer out here, and while I don't have a ton of computer access, I'll do what I can when I'm needed.  I hope that everyone is having a great day, and let me know if there's anything I can do!

~ThePlasmaGuy