### PR TITLE
Fixes to URL Parameters

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -496,10 +496,20 @@ function openURLKey() { // Handle Zoom / Reposition / Info Panel of URL specifie
 }
 
 function pushHistory() { // Push History State to URL
-    if (lastParamUpdate >= (Date.now() - paramUpdateDelay)) return;
+    function updateHist() {
     lastParamUpdate = Date.now();
+        window.history.replaceState({"html":'',"pageTitle":document.title},"", url.href);
+    }
 
-    window.history.pushState({"html":'',"pageTitle":document.title},"", url.href);
+    clearTimeout(updateHist);
+
+    var diff = Date.now() - lastParamUpdate;
+
+    if (diff < paramUpdateDelay) {
+        setTimeout(updateHist, paramUpdateDelay);
+    } else {
+        updateHist();
+    }
 }
 
 function toggleMapFullscreen(forceOpen=false) { // Toggle fullscreen state of page.  If forceOpen, page will be forced to fullscreen


### PR DESCRIPTION
I found two issues with the URL Parameters:
- Every time URL parameters are updated, it adds an entry to history, so as a result, back button history is flooded with entries when moving around the map or toggling visibility settings.
- If the URL parameters were updated within the last second and a parameter is changed, the changes will not appear in the URL until a change is made after the 1 second cooldown has passed. For example, if someone toggles the district event visibility, and then immediately toggles the regional event visibility within `paramUpdateDelay` milliseconds (currently 1 second), the regional event visibility will not appear in the URL parameters until another URL parameter is changed after the `paramUpdateDelay` cooldown has passed for toggling district event visibility.

I figured these are fairly simple issues to fix so I decided to make a pull request.

By using `window.history.replaceState` instead of `window.history.pushState`, only one entry in the browser back button history is preserved, so the user only has to press the back arrow once to return to the previous page.

I think it is still necessary to limit updates to the URL parameters to once a second because `window.history.replaceState` still seems to add to the browser history (at least on some browsers), just not to the back button history.

To fix the second problem, I use `setTimeout` and `clearTimeout` to make sure that the history can only be updated at most once a second, but will still be updated with the latest parameters after the cooldown has passed.