### PR TITLE
Do not show null postal code

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -429,8 +429,9 @@ function openInfo(marker) { // Create and show a Marker's InfoWindow
                 // Location list item
                 var locItem = document.createElement('li');
                 locItem.innerHTML = '<strong>Location:</strong> ';
-                var locText = parsed.city + ', ' + parsed.state_prov + ' ' + parsed.postal_code + ', ' +
-                    parsed.country;
+                var locText = parsed.city + ', ' + parsed.state_prov
+                    + (parsed.postal_code ? (' ' + parsed.postal_code) : '')
+                    + ', ' + parsed.country;
                 locItem.appendChild(document.createTextNode(locText));
                 list.appendChild(locItem);
 


### PR DESCRIPTION
Some teams, such as 7523, do not have postal code information available from The Blue Alliance, so their location includes "null" in place of the postal code:
![image](https://user-images.githubusercontent.com/9920632/62500770-df9bbd00-b7b5-11e9-89e9-a5d242cc7f4e.png)


This fixes the problem by ignoring the postal code if it is null:
![image](https://user-images.githubusercontent.com/9920632/62500704-bc710d80-b7b5-11e9-9ff8-c5bfa0300241.png)