### PR TITLE
Make links open in a new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <head>
         <meta charset="utf-8">
         <title>FIRSTMap</title>
+        <base target="_blank">
         <meta name="viewport" content="initial-scale=1.0">
         <link rel="stylesheet" href="https://unpkg.com/primer-tooltips@1.5.7/build/build.css">
         <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
Make all links open in a new tab by default. Before this, team websites and TBA pages opened in the same tab as the map, so in order to go back to the map the user had to hit the back button, and the map had to reload.

I feel like it makes more sense for team websites and TBA pages to open in a new tab by default, so the user can go back to the map more easily and without it reloading.

This also affects links on the About menu, which I think is fine. If any other links are added in the future that should not open in a new tab, it can be manually specified using the <a> tag's `target` attribute.