### PR TITLE
Fix fullscreen logo 404 error

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -59,11 +59,11 @@ a:hover { text-decoration: none; }
     cursor: pointer;
 }
 #fullscreen-controls {
-    background: white url('img/fullscreen.svg') no-repeat center;
+    background: white url('../img/fullscreen.svg') no-repeat center;
     background-size: 60%;
 }
 .fullscreen #fullscreen-controls {
-    background: white url('img/exit-fullscreen.svg') no-repeat center;
+    background: white url('../img/exit-fullscreen.svg') no-repeat center;
     background-size: 70%;
 }
 #about {


### PR DESCRIPTION
When the css files were moved to the css/ directory in #208, the browser started looking for the fullscreen logo at css/img/fullscreen.svg instead of img/fullscreen.svg. This corrects the issue by updating the image url in `style.css`.