### PR TITLE
Make [S] menu into magnifying glass and fix week numbers

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -66,6 +66,10 @@ a:hover { text-decoration: none; }
     background: white url('../img/exit-fullscreen.svg') no-repeat center;
     background-size: 70%;
 }
+#search-menu-button {
+    background: white url('../img/search.svg') no-repeat center;
+    background-size: 60%;
+}
 #about {
     position: fixed;
     top: 44px;

--- a/img/search.svg
+++ b/img/search.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="117mm" height="117mm" version="1.1" viewBox="0 0 117 117" xmlns="http://www.w3.org/2000/svg">
+<circle cx="42" cy="42" r="37" fill-opacity="0" stroke="#555" stroke-width="5"/>
+<path d="m67 67 45 45z" fill-opacity="0" stroke="#555" stroke-width="3"/>
+<circle cx="112" cy="112" r="1.5" stroke-width="0" fill="#555" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 
         <div id="toggles">
             <div onclick="toggleAbout()" class="tooltipped tooltipped-sw" aria-label="[Shift] View help and credits">?</div>
-            <div onclick="toggleSearch()" class="tooltipped tooltipped-sw" aria-label="[S] Open Search/Filter Menu">S</div>
+            <div onclick="toggleSearch()" id="search-menu-button" class="tooltipped tooltipped-sw" aria-label="[S] Open Search/Filter Menu">&nbsp;</div>
             <div onclick="toggleMarkers('team')" class="tooltipped tooltipped-sw" aria-label="[T] Toggle Team Markers">T</div>
             <div onclick="toggleMarkers('district')" class="tooltipped tooltipped-sw" aria-label="[D] Toggle District Markers">D</div>
             <div onclick="toggleMarkers('regional')" class="tooltipped tooltipped-sw" aria-label="[R] Toggle Regional Markers">R</div>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -567,7 +567,7 @@ async function openInfo(marker) { // Create and show a Marker's InfoWindow
             if (parsed.week) {
                 var weekItem = document.createElement('li');
                 weekItem.innerHTML += '<strong>Week:</strong> ';
-                weekItem.appendChild(document.createTextNode(parsed.week));
+                weekItem.appendChild(document.createTextNode(parsed.week + 1));
                 list.appendChild(weekItem);
             }
 


### PR DESCRIPTION
Change the search/filter menu button to a magnifying glass instead of the letter S. Fixes #217.

Week numbers from TBA are zero-indexed, so add 1 to the index to get the week number. Fixes #243.